### PR TITLE
Added known user-agent

### DIFF
--- a/src/linkding-refresh.py
+++ b/src/linkding-refresh.py
@@ -15,6 +15,7 @@ class LinkdingClient:
     def _request(self, url: str) -> {}:
         req = urllib.request.Request(url)
         req.add_header('Authorization', 'Token %s' % self._token)
+        req.add_header('User-Agent', 'Mozilla/5.0')
         r = urllib.request.urlopen(req)
         parsed = json.loads(r.read())
         return parsed


### PR DESCRIPTION
This makes the request look as if it is coming from a known user-agent, which resolves issues where the default `python` user-agent gets blocked due to anti bot security measures.